### PR TITLE
Fix hostage count extraction

### DIFF
--- a/index.js
+++ b/index.js
@@ -338,8 +338,14 @@ async function fetchHostageCountUsingWebSearch(apiKey, orgId) {
   try {
     const textSegments = assistantMsg.content.filter((seg) => seg.type === 'output_text');
     const answerText = textSegments.map((seg) => seg.text).join('\n');
-    const match = answerText.match(/\d+/);
-    const count = match ? match[0] : null;
+    // Prefer the number that appears near the word "hostage" to avoid
+    // accidentally picking a date (e.g. "July 22, 2024")
+    let countMatch = answerText.match(/(\d+)\s*(?=\w*\s*(?:hostage|hostages|captives|captors))/i);
+    if (!countMatch) {
+      // Fallback: use the first number in the response
+      countMatch = answerText.match(/\d+/);
+    }
+    const count = countMatch ? countMatch[1] : null;
     let citation = '';
     assistantMsg.content.forEach((seg) => {
       (seg.annotations || []).forEach((ann) => {


### PR DESCRIPTION
## Summary
- avoid capturing date digits when scraping hostage count

## Testing
- `node - <<'NODE'
const extract = answer => {
  let m = answer.match(/(\d+)\s*(?=\w*\s*(?:hostage|hostages|captives|captors))/i); if(!m)m=answer.match(/\d+/); return m?m[1]:null;};
console.log(extract('As of July 22, 2024, about 50 hostages remain.'));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_687ee04f280883239d552d04434cb861