### PR TITLE
[10-7] Improve env validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1271,11 +1271,18 @@ function validateEnv(env) {
     "OPEN_API_KEY_NEW",
     "OPENAI_ORG_ID",
   ];
-  requiredVars.forEach((varName) => {
+  for (const varName of requiredVars) {
     if (!env[varName]) {
-      throw new Error(`${varName} not set`);
+      return new Response(
+        JSON.stringify({ error: `${varName} not set` }),
+        {
+          status: 500,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
     }
-  });
+  }
+  return null;
 }
 
 function minifyCss(css) {
@@ -8037,13 +8044,9 @@ async function handleEducationModalRequest(body, env) {
 }
 
 async function handleRequest(request, env) {
-  try {
-    validateEnv(env);
-  } catch (err) {
-    return new Response(JSON.stringify({ error: err.message }), {
-      status: 500,
-      headers: { "Content-Type": "application/json" },
-    });
+  const envError = validateEnv(env);
+  if (envError) {
+    return envError;
   }
 
   const url = new URL(request.url);


### PR DESCRIPTION
- Add graceful error response in `validateEnv`
- Simplify environment check in `handleRequest`

## Validation
- `node --check index.js`
- `npx prettier index.js --check` *(fails: style issues)*

------
https://chatgpt.com/codex/tasks/task_e_68828d9d9d108323b6ea0ab1f09a316a