### PR TITLE
[10-7] Add rate limited API handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The JavaScript includes debounced input handling, ARIA attributes and error stat
 
 - **Frontend:** vanilla HTML5/CSS3 with modern JavaScript.  Animations are powered by [Anime.js](https://animejs.com).  The site is fully static and can be served from any HTTP server.  
 - **AI Integration:** The project uses the OpenAI API via a server‑side endpoint.  Environment variables (`OPENAI_API_KEY` and `OPENAI_ORG_ID`) keep credentials out of the client code.  
-- **Serverless Functions:** Endpoints under `/api/` handle tasks like hostage count retrieval, latest news scraping, chat completion and CTA generation.  They can be run in a Node.js environment or deployed to serverless platforms (e.g. Vercel, Netlify or Cloudflare Workers).  
+- **Serverless Functions:** Endpoints under `/api/` provide AI Q&A, heroic stories, regional insights and document analysis with rate limiting. They also handle hostage count retrieval, latest news scraping, chat completion and CTA generation. These functions run in Node.js or on serverless platforms such as Vercel, Netlify or Cloudflare Workers.
 - **Analytics & A/B Testing:** A simple event tracker records actions and call‑to‑action variants using `localStorage`/`sessionStorage`.  In production you can connect this data to services like Google Analytics or PostHog.
 
 ## Getting Started


### PR DESCRIPTION
- Implement in-memory rate limiting for API calls
- Add GPT-4 usage for ask and hero story endpoints with fallbacks
- Provide region insight caching and external stats fetch
- Support new `/api/region-insights` and `/api/analyze-document` routes
- Document updated serverless functions in README

**How to validate**
- `node --check index.js`
- `npx prettier index.js --check` *(optional warnings expected)*
- `node index.js` to ensure worker starts

------
https://chatgpt.com/codex/tasks/task_e_68844c1c34648323bd3fb815c46140a3