### PR TITLE
[10-7] Add hostages fetch fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ This playful tool conveys the exponential power of sharing knowledge.
 A dedicated section offers **actionable steps to support hostage families** – from wearing yellow ribbons to contacting representatives.  
 The platform emphasises solidarity and provides clear ways for anyone to help.
 
+The dedicated `/hostages` page lists every known hostage with search and lazy-loading of cards, pulling data from a public API when available.
+
 ### 📚 Educational Resources
 
 Curated **lesson plans, teaching guides, videos and statistics** help educators and learners deepen their understanding.  


### PR DESCRIPTION
- Added `fetchHostagesData` helper to request hostage info from hopeforhostages.com with fallback to local dataset
- Replaced internal API logic to use new helper and sanitised `/hostages` search query
- Ran `prettier` over `index.js`

**To validate:**
1. `node --check index.js`
2. `npx prettier index.js --check`


------
https://chatgpt.com/codex/tasks/task_e_6884511ad7dc832386f726d2425facc6