### PR TITLE
[10-7] Fix hero JS string escaping

### DIFF
--- a/index.js
+++ b/index.js
@@ -5507,7 +5507,7 @@ function getHtmlResponse() {
     "              }",
     "              ",
     "              const fallback = offlineData.scenarioFallbacks && currentScenario ? offlineData.scenarioFallbacks[currentScenario] : '';",
-    "              if (fallback) { chatResponse.innerHTML = 'Our AI service is currently unavailable. Here\'s what you need to know:<br>' + fallback; } else { chatResponse.textContent = errorMessage; }",
+    "              if (fallback) { chatResponse.innerHTML = 'Our AI service is currently unavailable. Here\\'s what you need to know:<br>' + fallback; } else { chatResponse.textContent = errorMessage; }",
     "              chatResponse.style.display = 'block';",
     "              chatResponse.setAttribute('aria-live', 'assertive');",
     "            }",


### PR DESCRIPTION
- escape apostrophe in hero error message to avoid JS syntax error
- ran prettier and node syntax check

To validate:
- `node --check index.js`
- `npx prettier index.js --check`

------
https://chatgpt.com/codex/tasks/task_e_6889037fc1208323a8ebe1156a15b517