### PR TITLE
[10-7] Escape closing script tags in JSON helper

### DIFF
--- a/index.js
+++ b/index.js
@@ -1437,9 +1437,11 @@ function minifyCss(css) {
   return css.replace(/\s+/g, " ").replace(/\s*([:{;})])\s*/g, "$1");
 }
 
-// Escape < characters so JSON can be safely embedded in <script> tags
+// Escape characters so JSON can be safely embedded in <script> tags
 function jsonForScript(data) {
-  return JSON.stringify(data).replace(/</g, "\\u003C");
+  return JSON.stringify(data)
+    .replace(/<\//g, "\\u003C/")
+    .replace(/</g, "\\u003C");
 }
 
 function getHtmlResponse() {


### PR DESCRIPTION
- Prevent accidental script termination by escaping `</` sequences
- Updated `jsonForScript` to replace `</` with `\u003C/`
- Validated syntax with `node --check index.js`

To verify:
- Run `node --check index.js` to confirm no syntax errors
- Deploy or run the worker and ensure pages render without `Unexpected end of script` errors.

------
https://chatgpt.com/codex/tasks/task_e_6889833cda6c8323bedacec28473d24d