### PR TITLE
[10-7] Escape script-tag HTML in JSON helper

### DIFF
--- a/index.js
+++ b/index.js
@@ -1441,7 +1441,8 @@ function minifyCss(css) {
 function jsonForScript(data) {
   return JSON.stringify(data)
     .replace(/<\//g, "\\u003C/")
-    .replace(/</g, "\\u003C");
+    .replace(/</g, "\\u003C")
+    .replace(/>/g, "\\u003E");
 }
 
 function getHtmlResponse() {


### PR DESCRIPTION
- Escape `>` characters in `jsonForScript` for safer embedding
- `node --check index.js` and `prettier` both pass

------
https://chatgpt.com/codex/tasks/task_e_68898657ad3c832396f38b8295700857