### PR TITLE
[10-7] Insert missing scriptClose tag

### DIFF
--- a/index.js
+++ b/index.js
@@ -7554,6 +7554,10 @@ function getHtmlResponse() {
     "        updateShare();",
     "      }",
     "      document.addEventListener('DOMContentLoaded', initImpactSimulator);",
+    // Properly close the Impact Simulator script block before closing the body.
+    // Without this, browsers see an unexpected end of script (see 10\u20117.org’s
+    // source around the impact simulator section for evidence).
+    scriptClose,
     "  </body>",
     "</html>",
   ];


### PR DESCRIPTION
- Properly close Impact Simulator script in `getHtmlResponse`
- Added comments about the fix
- Validated with `node --check` and `npx prettier --check`

To test:
1. Run `node --check index.js`
2. Optionally run `npx prettier index.js --check`

------
https://chatgpt.com/codex/tasks/task_e_6889b9a2f11c8323a4194432e13a2c4f